### PR TITLE
fix(astro): add workaround for nx not handling the project graph plugin without projectFilePatterns

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -8,10 +8,11 @@
 
 ## Features
 
-- Generator for scaffolding Astro applications and libraries.
+- Generators for scaffolding Astro applications and libraries.
+- Generators for scaffolding Astro components.
 - Cypress tests for Astro applications.
 - Executors to run builds, start the Astro development server and start a local static file server to preview built applications.
-- Nx project graph plugin to see Astro project dependencies.
+- Nx project graph plugin to visualize Astro project dependencies.
 
 ## Prerequisites
 

--- a/packages/astro/src/project-graph/plugin.ts
+++ b/packages/astro/src/project-graph/plugin.ts
@@ -12,6 +12,9 @@ import { readFileSync } from 'fs';
 import { extname } from 'path';
 import * as ts from 'typescript';
 
+// TODO: This is a temporary workaround until https://github.com/nrwl/nx/pull/8290 is merged
+export const projectFilePatterns = [];
+
 export function processProjectGraph(
   graph: ProjectGraph,
   context: ProjectGraphProcessorContext


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting a PR -->
<!-- https://github.com/nxtensions/nxtensions/blob/main/CONTRIBUTING.md#submitting-a-pr -->

## What it does

<!-- Describe the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue(s) being fixed so it gets closed when this is merged. -->

Fixes #
