### PR TITLE
fix(astro): support old cli terminal output

### DIFF
--- a/packages/astro/src/executors/dev/executor.spec.ts
+++ b/packages/astro/src/executors/dev/executor.spec.ts
@@ -27,6 +27,8 @@ function emitChildProcessStdioData(
   childProcessStdioDataEventStore[stdio] = value;
 }
 
+const oldAstroServerStartedTerminalOutput =
+  '01:49 PM [astro] Server started                               64ms';
 const astroServerStartedTerminalOutput = `
   🚀 [42m[30m astro [39m[49m [32mv0.24.0[39m [2mstarted in 476ms[22m
 
@@ -80,6 +82,16 @@ describe('Dev Executor', () => {
 
   test('should run successfully', async () => {
     emitChildProcessStdioData('stdout', astroServerStartedTerminalOutput);
+
+    const resultIterator = devExecutor({}, context);
+
+    const result = (await resultIterator.next()).value;
+    expect(result.success).toBe(true);
+    expect(fork).toHaveBeenCalled();
+  });
+
+  test('should support the old Astro CLI output', async () => {
+    emitChildProcessStdioData('stdout', oldAstroServerStartedTerminalOutput);
 
     const resultIterator = devExecutor({}, context);
 

--- a/packages/astro/src/executors/dev/executor.ts
+++ b/packages/astro/src/executors/dev/executor.ts
@@ -59,7 +59,8 @@ function runCliDev(
     process.on('exit', () => childProcess.kill());
     process.on('SIGTERM', () => childProcess.kill());
 
-    const serverStartedRegex = /Server started/;
+    const serverStartedRegex =
+      /(astro +v\d{1,3}.\d{1,3}.\d{1,3} started in \d+ms|Server started)/;
     childProcess.stdout.on('data', (data) => {
       process.stdout.write(data);
 

--- a/packages/astro/src/executors/dev/executor.ts
+++ b/packages/astro/src/executors/dev/executor.ts
@@ -59,8 +59,7 @@ function runCliDev(
     process.on('exit', () => childProcess.kill());
     process.on('SIGTERM', () => childProcess.kill());
 
-    const serverStartedRegex =
-      /astro +v\d{1,3}.\d{1,3}.\d{1,3} started in \d+ms/;
+    const serverStartedRegex = /Server started/;
     childProcess.stdout.on('data', (data) => {
       process.stdout.write(data);
 

--- a/packages/astro/src/executors/preview/executor.spec.ts
+++ b/packages/astro/src/executors/preview/executor.spec.ts
@@ -27,6 +27,8 @@ function emitChildProcessStdioData(
   childProcessStdioDataEventStore[stdio] = value;
 }
 
+const oldAstroServerStartedTerminalOutput =
+  '01:49 PM [astro] Server started                               64ms';
 const astroServerStartedTerminalOutput = `
   🚀 [42m[30m astro [39m[49m [32mv0.24.0[39m [2mstarted in 476ms[22m
 
@@ -80,6 +82,16 @@ describe('Preview Executor', () => {
 
   test('should run successfully', async () => {
     emitChildProcessStdioData('stdout', astroServerStartedTerminalOutput);
+
+    const resultIterator = previewExecutor({}, context);
+
+    const result = (await resultIterator.next()).value;
+    expect(result.success).toBe(true);
+    expect(fork).toHaveBeenCalled();
+  });
+
+  test('should support the old Astro CLI output', async () => {
+    emitChildProcessStdioData('stdout', oldAstroServerStartedTerminalOutput);
 
     const resultIterator = previewExecutor({}, context);
 

--- a/packages/astro/src/executors/preview/executor.ts
+++ b/packages/astro/src/executors/preview/executor.ts
@@ -60,7 +60,7 @@ function runCliPreview(
     process.on('SIGTERM', () => childProcess.kill());
 
     const serverStartedRegex =
-      /astro +v\d{1,3}.\d{1,3}.\d{1,3} started in \d+ms/;
+      /(astro +v\d{1,3}.\d{1,3}.\d{1,3} started in \d+ms|Server started)/;
     childProcess.stdout.on('data', (data) => {
       process.stdout.write(data);
 


### PR DESCRIPTION
There is an issue regarding the e2e tests using cypress and the `dev` target that cannot be able to start properly.

The executor `@nrwl/cypress` uses the `devServerTarget` to run the target first and then boot cypress. You can see it here https://github.com/nrwl/nx/blob/master/packages/cypress/src/executors/cypress/cypress.impl.ts#L143

There was no successful response so cypress was unable to start it correctly.
Due to changes in the regex on the  the `dev` executor the ``was unable to detect that the `devServerTarget`
![image](https://user-images.githubusercontent.com/17608169/159091680-70748b5a-15b7-4e3c-b95d-b50251087142.png)

Reviewing the code, I found that the regex expression to resolve the promise was not quite right. Instead of using "started" which is no longer the output of Astro, I change the value to "Server started".


Current Behavior: 
https://user-images.githubusercontent.com/17608169/159092569-ae11b704-6f14-4436-8362-9a87b3f8fa3d.mp4

New Behavior: 
https://user-images.githubusercontent.com/17608169/159092465-f92a74d9-0b3a-456d-9cf8-3fb161afda17.mp4




