### PR TITLE
fix(astro): handle —host boolean value correctly in dev executor

### DIFF
--- a/packages/astro/src/executors/dev/executor.ts
+++ b/packages/astro/src/executors/dev/executor.ts
@@ -99,7 +99,11 @@ function getAstroDevArgs(
     args.push('--drafts');
   }
   if (options.host !== undefined) {
-    args.push('--host', options.host.toString());
+    if (typeof options.host === 'boolean' && options.host === true) {
+      args.push('--host');
+    } else {
+      args.push('--host', options.host.toString());
+    }
   }
   if (options.port) {
     args.push('--port', options.port.toString());

--- a/packages/astro/src/executors/dev/executor.ts
+++ b/packages/astro/src/executors/dev/executor.ts
@@ -99,8 +99,8 @@ function getAstroDevArgs(
     args.push('--drafts');
   }
   if (options.host !== undefined) {
-    if (typeof options.host === 'boolean' && options.host === true) {
-      args.push('--host');
+    if (typeof options.host === 'boolean') {
+      args.push(options.host === true ? '--host' : '--no-host');
     } else {
       args.push('--host', options.host.toString());
     }


### PR DESCRIPTION
## What it does
This fixes an issue where setting { host: true } in the @nxtensions/astro:dev options config causes an error.

Instead of always passing the `host` arg as a string, this change checks the type of `host` and if it is a `boolean`:

- only adds --host if it is true
- does not add --host otherwise

For `string` types the behavior is as it was before.