### PR TITLE
feat(astro): pin generated astro version to 2.9.6

### DIFF
--- a/packages/astro/src/generators/init/versions.ts
+++ b/packages/astro/src/generators/init/versions.ts
@@ -1,1 +1,3 @@
-export const astroVersion = '^2.0.0';
+// TODO(leo): temporary pin version to 2.9.6 (last working version) until
+// https://github.com/withastro/astro/issues/7934 is addressed.
+export const astroVersion = '2.9.6';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting a PR -->
<!-- https://github.com/nxtensions/nxtensions/blob/main/CONTRIBUTING.md#submitting-a-pr -->

## What it does
<!-- Describe the changes in this PR -->

Pins the generated version of Astro to 2.9.6 as workaround for an Astro issue introduced in 2.9.7 that breaks the root path resolution in monorepos. For more context and other workarounds for higher versions, see https://github.com/nxtensions/nxtensions/issues/445#issuecomment-1666485160.

## Related Issue(s)
<!-- Please link the issue(s) being fixed so it gets closed when this is merged. -->

Fixes #
