### PR TITLE
fix(astro): makes the nx patch exit normally instead of throwing an error

### DIFF
--- a/packages/astro/src/generators/init/files/patch-nx-cli.js__tmpl__
+++ b/packages/astro/src/generators/init/files/patch-nx-cli.js__tmpl__
@@ -25,5 +25,5 @@ try {
   );
 } catch (e) {
   console.error('The Nx CLI could not be patched.');
-  throw e;
+  process.exit(0);
 }


### PR DESCRIPTION
In CI/production build environments the build isn't supposed to have access to the Nx CLI and related packages. Because the patch is added to the postinstall step of the installation, this would break the build process in cases of running npm ci and related production build steps.

<!-- Please make sure you have read the submission guidelines before posting a PR -->
<!-- https://github.com/nxtensions/nxtensions/blob/main/CONTRIBUTING.md#submitting-a-pr -->