### PR TITLE
fix(astro): on windows platform executors fail to spawn astro process

### DIFF
--- a/packages/astro/src/executors/build/executor.spec.ts
+++ b/packages/astro/src/executors/build/executor.spec.ts
@@ -83,8 +83,11 @@ describe('Build Executor', () => {
 
     await buildExecutor({ deleteOutputPath: true }, context);
 
+    const expectedPathToRemove =
+      process.platform === 'win32' ? 'dist\\apps\\app1' : 'dist/apps/app1';
+
     expect(fsExtra.removeSync).toHaveBeenCalledWith(
-      expect.stringContaining('dist/apps/app1')
+      expect.stringContaining(expectedPathToRemove)
     );
   });
 

--- a/packages/astro/src/executors/build/executor.ts
+++ b/packages/astro/src/executors/build/executor.ts
@@ -58,7 +58,9 @@ function runCliBuild(
       ['build', ...getAstroBuildArgs(projectRoot, options)],
       {
         cwd: workspaceRoot,
+        env: { ...process.env, FORCE_COLOR: 'true' },
         stdio: 'inherit',
+        shell: process.platform === 'win32',
       }
     );
 

--- a/packages/astro/src/executors/check/executor.ts
+++ b/packages/astro/src/executors/check/executor.ts
@@ -35,7 +35,9 @@ function runCliCheck(workspaceRoot: string, projectRoot: string) {
       ['check', ...getAstroCheckArgs(projectRoot)],
       {
         cwd: workspaceRoot,
+        env: { ...process.env, FORCE_COLOR: 'true' },
         stdio: 'inherit',
+        shell: process.platform === 'win32',
       }
     );
 

--- a/packages/astro/src/executors/dev/executor.ts
+++ b/packages/astro/src/executors/dev/executor.ts
@@ -49,6 +49,7 @@ function runCliDev(
         cwd: workspaceRoot,
         env: { ...process.env, FORCE_COLOR: 'true' },
         stdio: 'pipe',
+        shell: process.platform === 'win32',
       }
     );
 

--- a/packages/astro/src/executors/preview/executor.ts
+++ b/packages/astro/src/executors/preview/executor.ts
@@ -48,6 +48,7 @@ function runCliPreview(
         cwd: workspaceRoot,
         env: { ...process.env, FORCE_COLOR: 'true' },
         stdio: 'pipe',
+        shell: process.platform === 'win32',
       }
     );
 

--- a/packages/astro/src/executors/sync/executor.ts
+++ b/packages/astro/src/executors/sync/executor.ts
@@ -32,7 +32,9 @@ function runCliSync(workspaceRoot: string, projectRoot: string) {
     // TODO: use Astro CLI API: https://docs.astro.build/en/reference/cli-reference/#advanced-apis-experimental
     childProcess = spawn('astro', ['sync', ...getAstroSyncArgs(projectRoot)], {
       cwd: workspaceRoot,
+      env: { ...process.env, FORCE_COLOR: 'true' },
       stdio: 'inherit',
+      shell: process.platform === 'win32',
     });
 
     // Ensure the child process is killed when the parent exits


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting a PR -->
<!-- https://github.com/nxtensions/nxtensions/blob/main/CONTRIBUTING.md#submitting-a-pr -->

## What it does

On Windows platform executors fail to spawn `astro` process with error:

```
Error: spawn astro ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

`child_process.spawn()` uses `shell: false` by default, so I set it to `true` in case of Windows platform. Also passed env to `build`, `check` and `sync` calls.
